### PR TITLE
Include parent_station in stops for merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Can also use zipfile bytes as input, this is useful for [Boto3](http://boto3.rea
 ```python
 >>> merged_gtfs = GTFSMerger()
 >>> f_1 = open('tests/test_gtfs.zip', 'rb').read()
->>> f_2 = open('tests/test_gtfs_2', 'rb').read()
+>>> f_2 = open('tests/test_gtfs_2.zip', 'rb').read()
 >>> merged_gtfs.merge_from_bytes_list([f_1, f_2])
 ```
 
@@ -40,19 +40,20 @@ dict_keys(['stops', 'stop_times', 'calendar_dates', 'shapes', 'agency', 'routes'
 To access the `stops` GTFS Pandas Dataframe
 ```python
 >>> merged_gtfs.merged['stops'].head()
-stop_id    stop_name  stop_desc   stop_lat    stop_lon stop_url  \
+      stop_id    stop_name  stop_desc   stop_lat    stop_lon stop_url  \
 0   0-n1502-1      美感ホール入口  掛川市内循環南回り  34.767448  138.010986      NaN
 1  0-n62046-1  中東遠総合医療センター  掛川市内循環南回り  34.757321  137.998436      NaN
 2   0-n1520-1       中央小学校前  掛川市内循環南回り  34.770991  138.005292      NaN
 3   0-n1522-1      労金掛川支店前  掛川市内循環南回り  34.770798  138.008737      NaN
 4     0-n1510      下俣南二丁目西  掛川市内循環南回り  34.762361  138.001036      NaN
 
- location_type parent_station wheelchair_boarding
-0             0          n1502                   0
-1             0         n62046                   0
-2             0          n1520                   0
-3             0          n1522                   0
+  location_type parent_station wheelchair_boarding
+0             0        0-n1502                   0
+1             0       0-n62046                   0
+2             0        0-n1520                   0
+3             0        0-n1522                   0
 4             1            NaN                   0
+
 ```
 
 ## Development

--- a/conftest.py
+++ b/conftest.py
@@ -20,8 +20,9 @@ def gtfs_obj_from_bytes():
 def gtfs_merger():
     _gtfs = GTFSMerger()
     _gtfs.merge_from_fpaths([
-    	'tests/test_gtfs.zip', 'tests/test_gtfs_2.zip'])
+        'tests/test_gtfs.zip', 'tests/test_gtfs_2.zip'])
     return _gtfs
+
 
 @pytest.fixture(scope='module')
 def gtfs_merger_from_bytes():

--- a/gtfsmerger/__init__.py
+++ b/gtfsmerger/__init__.py
@@ -9,7 +9,7 @@ class GTFSMerger(object):
         'calendar': ['service_id'],
         'calendar_dates': ['service_id'],
         'stop_times': ['trip_id', 'stop_id'],
-        'stops': ['stop_id'],
+        'stops': ['stop_id', 'parent_station'],
         'shape': ['shape_id'],
         'trips': ['route_id', 'trip_id', 'service_id'],
         'transfer': ['from_stop_id', 'to_stop_id'],
@@ -47,7 +47,8 @@ class GTFSMerger(object):
             columns = cls.ref_id[ref]
             for col in columns:
                 try:
-                    gtfs[ref][col] = gtfs[ref][col].apply(lambda x: tag + x)
+                    gtfs[ref][col] = gtfs[ref][col].apply(
+                        lambda x: tag + x if not pd.isnull(x) else x)
                 except KeyError:
                     pass
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 setup(
     name='gtfsmerger',
-    version='0.1.2',
+    version='0.1.3',
     description='Merge multiple GTFS files into one',
     author='Door2Door GmbH',
     author_email='chenghsun@door2door.io',

--- a/tests/test_gtfsmerger.py
+++ b/tests/test_gtfsmerger.py
@@ -1,4 +1,5 @@
 from gtfsmerger import GTFSMerger
+import pandas as pd
 
 
 def test_gtfs_merger(gtfs_merger):
@@ -8,6 +9,13 @@ def test_gtfs_merger(gtfs_merger):
         u'0-n1520-1',
         u'0-n1522-1',
         u'0-n1510']
+
+    assert gtfs_merger.merged['stops'].iloc[:4]['parent_station'].tolist() == [
+        '0-n1502', '0-n62046', '0-n1520', '0-n1522']
+
+    assert pd.isnull(gtfs_merger.merged['stops'].iloc[5][
+        'parent_station'])
+
     z_p = gtfs_merger.get_zipfile()
 
     assert set(z_p.namelist()) == set([
@@ -28,6 +36,14 @@ def test_gtfs_merger_from_bytes(gtfs_merger_from_bytes):
             u'0-n1520-1',
             u'0-n1522-1',
             u'0-n1510']
+
+    assert gtfs_merger_from_bytes.merged['stops'].iloc[:4][
+        'parent_station'].tolist() == [
+            '0-n1502', '0-n62046', '0-n1520', '0-n1522']
+
+    assert pd.isnull(gtfs_merger_from_bytes.merged['stops'].iloc[5][
+        'parent_station'])
+
     z_p = gtfs_merger_from_bytes.get_zipfile()
 
     assert set(z_p.namelist()) == set([


### PR DESCRIPTION
When merging stops.txt from multiple gtfs files, all "stop_id" is appended with a file count. "parent_station" should also be included in this change since "stop_is" and "parent_station" reference each other.

This PR will include parent_station in stops.txt for adding a file count.

Also remember to publish the changes to pip.